### PR TITLE
address dual dts issues

### DIFF
--- a/.changeset/lovely-adults-brush.md
+++ b/.changeset/lovely-adults-brush.md
@@ -1,0 +1,5 @@
+---
+"@effect/build-utils": patch
+---
+
+generate proxy d.ts for cjs and esm, to address dual package hazard

--- a/.changeset/lovely-adults-brush.md
+++ b/.changeset/lovely-adults-brush.md
@@ -2,4 +2,4 @@
 "@effect/build-utils": patch
 ---
 
-generate proxy d.ts for cjs and esm, to address dual package hazard
+Generate proxy `.d.ts` for `cjs` and `esm` and enable automatic `.d.ts` resolution.


### PR DESCRIPTION
I think I found the structural fix for the dual dts problem, exposed for example when you start using `fast-check` with schema from an esm project.

The problem appears to stem from that a single dts file exposed from package.json can only be interpeted either as cjs or as esm, which will dictate which dts it will load from external packages, which for better or worse, can have different .d.ts files for esm and cjs.
In the case of schema that turns out to be the cjs version of fast-check, leading to the problem once you mix it from an esm source.

The fix is by creating individual proxy .d.ts for cjs and esm, but re-exporting from a single source of dts truth, so that symbols remain unique