### PR TITLE
fix: enhance PackageJson author schema

### DIFF
--- a/.changeset/forty-countries-run.md
+++ b/.changeset/forty-countries-run.md
@@ -1,0 +1,5 @@
+---
+"@effect/build-utils": patch
+---
+
+enhance PackageJson author schema

--- a/src/PackageContext.ts
+++ b/src/PackageContext.ts
@@ -61,7 +61,7 @@ export class PackageJson extends Schema.Class<PackageJson>("PackageJson")({
         email: Schema.String,
         url: Schema.optional(Schema.String),
       }),
-    )
+    ),
   ),
   repository: Schema.Union(
     Schema.String,

--- a/src/PackageContext.ts
+++ b/src/PackageContext.ts
@@ -53,7 +53,14 @@ export class PackageJson extends Schema.Class<PackageJson>("PackageJson")({
     executableFiles: Schema.optional(Schema.Array(Schema.String)),
   })),
   license: Schema.String,
-  author: Schema.optional(Schema.String),
+  author: Schema.Union(
+    Schema.String,
+    Schema.Struct({
+      name: Schema.String,
+      email: Schema.String,
+      url: Schema.optional(Schema.String),
+    }),
+  ),
   repository: Schema.Union(
     Schema.String,
     Schema.Struct({

--- a/src/PackageContext.ts
+++ b/src/PackageContext.ts
@@ -53,13 +53,15 @@ export class PackageJson extends Schema.Class<PackageJson>("PackageJson")({
     executableFiles: Schema.optional(Schema.Array(Schema.String)),
   })),
   license: Schema.String,
-  author: Schema.Union(
-    Schema.String,
-    Schema.Struct({
-      name: Schema.String,
-      email: Schema.String,
-      url: Schema.optional(Schema.String),
-    }),
+  author: Schema.optional(
+    Schema.Union(
+      Schema.String,
+      Schema.Struct({
+        name: Schema.String,
+        email: Schema.String,
+        url: Schema.optional(Schema.String),
+      }),
+    )
   ),
   repository: Schema.Union(
     Schema.String,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `author` attribute in `PackageJson` schema can be an object, [see here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#people-fields-author-contributors)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

Had to patch it [here](https://github.com/floydspace/effect-kafka/blob/main/patches/%40effect__build-utils.patch)
