### PR TITLE
Fix PrepareV2.ts when running on windows

### DIFF
--- a/.changeset/strange-berries-roll.md
+++ b/.changeset/strange-berries-roll.md
@@ -1,0 +1,5 @@
+---
+"@effect/build-utils": patch
+---
+
+fix PrepareV2.ts on windows

--- a/src/PrepareV2.ts
+++ b/src/PrepareV2.ts
@@ -25,7 +25,7 @@ export const run = Effect.gen(function*() {
   })
 
   const modules = entrypoints
-    .map(file => file.replace(/\.ts$/, ""))
+    .map(file => file.replace(/\\/, "/").replace(/\.ts$/, ""))
     .sort()
 
   const template = yield* fs.readFileString("src/.index.ts").pipe(


### PR DESCRIPTION
there's logic based on slashes in regexes, which of course don't work on windows where the paths contain backslashes instead.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

the `PrepareV2` code assumed non-windows machines

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
